### PR TITLE
Fixed the create chatroom app crashing bug

### DIFF
--- a/GeoChat/screens/CreateChatRoom.js
+++ b/GeoChat/screens/CreateChatRoom.js
@@ -35,10 +35,9 @@ class CreateChatRoom extends React.Component{
       this.props.history.push("/chat-list")
     }
 
-    handleChange = (e) => {
-
-      this.setState({[e.target.name] : e.target.value})
-      // console.log("", e)
+    handleChange = (field, value) => {
+      // console.log("field: ", field, "value: ", value)
+      this.setState({[field]: value})
     }
 
     goBack = () => {
@@ -78,8 +77,8 @@ class CreateChatRoom extends React.Component{
 
             <View style={styles.container}>
                 <Button title="Go back" onPress={this.goBack} />
-                <TextInput name="roomName" style={styles.textBox} placeholder="Chat room name" onChangeText={this.handleChange} value={this.state.roomName} maxLength={20} />
-                <TextInput name="roomDescription" style={styles.textBox} placeholder="Chat room name" onChangeText={this.handleChange} value={this.state.roomDescription} maxLength={200} />
+                <TextInput name="roomName" style={styles.textBox} placeholder="Chat room name" onChangeText={this.handleChange.bind(this, "roomName")} value={this.state.roomName} maxLength={20} />
+                <TextInput name="roomDescription" style={styles.textBox} placeholder="Chat room name" onChangeText={this.handleChange.bind(this, "roomDescription")} value={this.state.roomDescription} maxLength={200} />
                 <Button title="Choose your chatroom Image" onPress={this.pickImage} />
                 {this.state.roomAvatar ? <Image source={{uri : this.state.roomAvatar}} style={{width:200, height:200}}/> : null}
                 <Button title="Submit" onPress={this.newRoom} />


### PR DESCRIPTION
# Description

Fixes # (issue)
When entering text into the `CreateChatroom` fields it caused the app to crash.

## Type of change
So for some reason, `event` or `e` doesn't work the same in react native. I had to change the way the forms used the `onChangeText` The `handleChange` function had to be changed to this:
`this.handleChange.bind(this, 'nameOfStateValue')` 
I got this solution from SE:
https://stackoverflow.com/questions/53982159/how-to-use-event-value-in-react-native

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)

## Change Status

-   [ ] Complete, tested, ready to review and merge
-   [X] Complete, but not tested (may need new tests)
-   [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?
Manually
-   [ ] Test A
-   [ ] Test B

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my own code
-   [ ] My code has been reviewed by at least one peer
-   [X] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [X] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
-   [X] There are no merge conflicts
